### PR TITLE
Add Note UI will now receive SEND text/plain intents.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
-    testImplementation 'junit:junit:4.12'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
+    testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation("com.squareup.okhttp3:okhttp:4.9.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--suppress AndroidElementNotAllowed -->
+<!-- The above suppression is necessary due to the <queries> tag, which is meaningless in older SDKs
+     but is critical to looking up package names on Android devices running SDK 30.-->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.github.zadam.triliumsender">
 
@@ -16,8 +19,8 @@
             android:label="Trilium connection setup" />
         <activity
             android:name=".MainActivity"
-            android:taskAffinity=".MainActivity"
             android:label="@string/app_name"
+            android:taskAffinity=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -38,15 +41,32 @@
         </activity>
         <activity
             android:name=".SendNoteActivity"
-            android:taskAffinity=".SendNoteActivity"
             android:label="Add note"
+            android:taskAffinity=".SendNoteActivity"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="text/plain" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="image/*" />
+        </intent>
+    </queries>
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="sender_not_configured_note">Trilium Sender is not configured. Can\'t compose note.</string>
     <string name="sending_note_complete">Note sent to Trilium.</string>
     <string name="sending_note_failed">Sending note to Trilium failed.</string>
+    <string name="share_note_title">Shared from %s</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Now, many more apps can share directly into Trilium Sender.

For example, here's me sharing a link to a discussion from a cool photo on reddit:
<img src="https://user-images.githubusercontent.com/4315099/95711831-6cdb6c80-0c18-11eb-85f6-038f8f4b89ea.png" width=300/> 
The Add Note UI is pre-populated with the contents of the message (usually just a link) and, in this case, the title of the link.
<img src="https://user-images.githubusercontent.com/4315099/95711982-baf07000-0c18-11eb-966e-186d9f9cea39.png" width=300/> 

In the event that an app doesn't provide a note title via the EXTRA_SUBJECT metadata, we'll try to look up the app's name for a default note title. Twitter, for example:
<img src="https://user-images.githubusercontent.com/4315099/95712438-9b0d7c00-0c19-11eb-95db-02ae85e6396f.png" width=300/> 
Here, it hasn't provided EXTRA_SUBJECT, so we craft this default title:
<img src="https://user-images.githubusercontent.com/4315099/95712517-b5475a00-0c19-11eb-84af-290c6e3eccd6.png" width=300/> 

It is possible for this app name lookup to fail. In that case, we would fall back to the note title "Shared from Android".

Drive-by: update a couple of packages.

As before, if you find this valuable, please consider adding the `hacktoberfest-accepted` label to this PR. :)

Thanks for your review!