### PR TITLE
Users can now specify a note label to apply to their sent notes.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".LoginActivity"
-            android:label="Trilium connection setup" />
+            android:label="@string/trilium_sender_settings" />
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"

--- a/app/src/main/java/io/github/zadam/triliumsender/MainActivity.kt
+++ b/app/src/main/java/io/github/zadam/triliumsender/MainActivity.kt
@@ -16,7 +16,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         if (resetSetup) {
-            TriliumSettings(this).save("", "")
+            TriliumSettings(this).save("", "", "")
         }
 
         setContentView(R.layout.activity_main)

--- a/app/src/main/java/io/github/zadam/triliumsender/services/TriliumSettings.kt
+++ b/app/src/main/java/io/github/zadam/triliumsender/services/TriliumSettings.kt
@@ -8,12 +8,14 @@ class TriliumSettings constructor(ctx: Activity) {
         const val PREF_NAME = "io.github.zadam.triliumsender.setup"
         const val PREF_TRILIUM_ADDRESS = "trilium_address"
         const val PREF_API_TOKEN = "api_token"
+        const val PREF_NOTE_LABEL = "trilium_note_label"
     }
 
-    fun save(triliumAddress: String, apiToken: String) {
+    fun save(triliumAddress: String, apiToken: String, noteLabel: String) {
         val editor = prefs.edit()
         editor.putString(PREF_TRILIUM_ADDRESS, triliumAddress)
         editor.putString(PREF_API_TOKEN, apiToken)
+        editor.putString(PREF_NOTE_LABEL, noteLabel)
         editor.apply()
     }
 
@@ -24,6 +26,9 @@ class TriliumSettings constructor(ctx: Activity) {
 
     val apiToken
         get() = prefs.getString(PREF_API_TOKEN, "")!!
+
+    val noteLabel
+        get() = prefs.getString(PREF_NOTE_LABEL, "")!!
 
     fun isConfigured() = !triliumAddress.isBlank() && !apiToken.isBlank()
 }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -28,6 +28,12 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
+            <TextView
+                android:id="@+id/LoginSettingsLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/login_settings_header" />
+
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
@@ -87,6 +93,35 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/action_login"
                 android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/loggedInIndicator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/logged_in_successfully" />
+
+            <TextView
+                android:id="@+id/NoteSettingsLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/note_settings_header" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <EditText
+                    android:id="@+id/labelEditText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/prompt_label"
+                    android:importantForAutofill="no"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:singleLine="true" />
+
+            </com.google.android.material.textfield.TextInputLayout>
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_send_note.xml
+++ b/app/src/main/res/layout/activity_send_note.xml
@@ -22,6 +22,12 @@
             android:hint="@string/note_title"
             android:importantForAutofill="no" />
 
+        <TextView
+            android:id="@+id/labelList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="" />
+
         <EditText
             android:id="@+id/noteContentEditText"
             android:layout_width="match_parent"
@@ -47,5 +53,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:focusable="true"
+        android:contentDescription="@string/send_fab_content_desc"
         app:srcCompat="@android:drawable/ic_menu_send" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,13 +3,14 @@
     <string name="prompt_trilium_address">https://trilium_host:8080</string>
     <string name="prompt_username">User name</string>
     <string name="prompt_password">Password</string>
+    <string name="prompt_label">Label for sent notes</string>
     <string name="action_login">Login</string>
     <string name="action_login_short">Login</string>
     <string name="error_network_error">Network error</string>
     <string name="error_unexpected_response">Unexpected response from server</string>
     <string name="error_incorrect_credentials">Entered credentials are incorrect</string>
     <string name="error_field_required">This field is required</string>
-    <string name="trilium_connection_settings">Trilium connection settings</string>
+    <string name="trilium_connection_settings">Settings</string>
     <string name="note_title">Note title</string>
     <string name="note_text">Note text</string>
     <string name="setup_not_complete">Trilium connection setup isn\'t finished yet.</string>
@@ -24,4 +25,10 @@
     <string name="sending_note_complete">Note sent to Trilium.</string>
     <string name="sending_note_failed">Sending note to Trilium failed.</string>
     <string name="share_note_title">Shared from %s</string>
+    <string name="login_settings_header">Login Settings</string>
+    <string name="note_settings_header">Note Settings</string>
+    <string name="label_preview_template">#%s</string>
+    <string name="logged_in_successfully">Login credentials are saved! ✅</string>
+    <string name="send_fab_content_desc">Send.</string>
+    <string name="trilium_sender_settings">Trilium Sender Settings</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 13 12:15:13 PDT 2020
+#Sun Nov 08 18:02:32 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
* Some UI shuffling and tweaks to support the new capabiltiy.
* Bump gradle version.

I ran into some issues while developing this, outlined in https://github.com/zadam/trilium/issues/1397
We should not merge this change until that bug is fixed.