### PR TITLE
Allow URLs to be shared to the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,14 @@
 
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
     </application>
 


### PR DESCRIPTION
I often read interesting articles on my mobile devices and would sharing URLs to trilium-sender could be easier. This PR adds an additional intent-filter so URLs (scheme http and https) can be shared directly to trilium sender. 