### PR TITLE
Explicitly opt in to clearTextTraffic

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
Hi zadam,

I noticed that after upgrading from 0.1 to 0.2 I was seeing "Network Error" when attempting to set the trilium url.

Logcat shows:
`UserLoginCoroutine: java.net.UnknownServiceException: CLEARTEXT communication to http://my_server_url not permitted by network security policy`

Note that I'm using http not https.

According to [docs](https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted) cleartext support is disabled by defaullt starting with Android 9. My device is on Android 12.
